### PR TITLE
Fix build command

### DIFF
--- a/.travis-ci.d/compile_and_test.sh
+++ b/.travis-ci.d/compile_and_test.sh
@@ -19,7 +19,8 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-make install VERBOSE=1
+# make install VERBOSE=1
+make install -j 4
 
 if [ $? -ne 0 ]; then
     echo "Failed to run make"

--- a/.travis-ci.d/compile_and_test.sh
+++ b/.travis-ci.d/compile_and_test.sh
@@ -19,8 +19,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# make install VERBOSE=1
-make install -j 4
+make install VERBOSE=1
 
 if [ $? -ne 0 ]; then
     echo "Failed to run make"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,6 @@ if( DQM4HEP_TESTING )
   set( DQM4HEP_TEST_COMMAND "ctest" )
 endif()
 
-set( CUSTOM_BUILD_COMMAND make install )
 set( COVERITY_SCAN_DIR "${PROJECT_BINARY_DIR}/cov-int" )
 if( DQM4HEP_COVERITY_SCAN )
   set( CUSTOM_BUILD_COMMAND cov-build --dir ${COVERITY_SCAN_DIR} make install )

--- a/cmake/dqm4hep_compiler_settings.cmake
+++ b/cmake/dqm4hep_compiler_settings.cmake
@@ -18,7 +18,7 @@ macro( DQM4HEP_SET_CXX_FLAGS )
   set( COMPILER_FLAGS -Wunused-value -Wall -pedantic -Wshadow -Wformat-security -Wno-long-long -Wreturn-type -Wuseless-cast -Wlogical-op -Wredundant-decls -Weffc++ -Wno-unsequenced -Wno-deprecated-declarations -fdiagnostics-color=auto  )
   
   if( DQM4HEP_DEV_WARNINGS )
-    set( COMPILER_FLAGS ${COMPILER_FLAGS} -Wsuggest-final-types -Wsuggest-override -Wno-comments -Wparentheses )
+    set( COMPILER_FLAGS ${COMPILER_FLAGS} -Wsuggest-override -Wno-comments -Wparentheses )
   endif()
   
   if( DQM4HEP_WARNING_AS_ERROR )


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixed BUILD_COMMAND in case coverity scan mode is not set
- Causes additional argument such as `-j 4` to do not be passed to sub-packages command line
- Removed annoying dev warning flag `-Wsuggest-final-types`

ENDRELEASENOTES