### PR TITLE
Added --output-on-failure argument to ctest command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ if( DQM4HEP_BUILD_OFFLINE )
 endif()
 
 if( DQM4HEP_TESTING )
-  set( DQM4HEP_TEST_COMMAND "ctest" )
+  set( DQM4HEP_TEST_COMMAND ctest --output-on-failure )
 endif()
 
 set( COVERITY_SCAN_DIR "${PROJECT_BINARY_DIR}/cov-int" )


### PR DESCRIPTION

BEGINRELEASENOTES
- Added --output-on-failure argument to ctest command

ENDRELEASENOTES