### PR TITLE
Fix new llvm warning gcc error

### DIFF
--- a/DQMCore/include/dqm4hep/Archiver.h
+++ b/DQMCore/include/dqm4hep/Archiver.h
@@ -11,6 +11,9 @@
 #ifndef DQM4HEP_ARCHIVER_H
 #define DQM4HEP_ARCHIVER_H
 
+// -- stl headers
+#include <functional>
+
 // -- dqm4hep headers
 #include "dqm4hep/Internal.h"
 #include "dqm4hep/StatusCodes.h"

--- a/DQMCore/include/dqm4hep/Handle.h
+++ b/DQMCore/include/dqm4hep/Handle.h
@@ -18,6 +18,7 @@
 #include <typeinfo>
 #include <typeindex>
 #include <memory>
+#include <functional>
 
 namespace dqm4hep {
   

--- a/DQMOnline/include/dqm4hep/OnlineElement.h
+++ b/DQMOnline/include/dqm4hep/OnlineElement.h
@@ -128,14 +128,14 @@ namespace dqm4hep {
        *
        *  @param  resetQtests whether to also reset the quality tests 
        */
-      virtual void reset(bool resetQtests = true);
-      
+      virtual void reset(bool resetQtests = true) override;
+
       /**
        *  @brief  Convert the monitor element to json
        *  
        *  @param  object the json object to receive
        */
-      virtual void toJson(core::json &object) const;
+      virtual void toJson(core::json &object) const override;
       
 // #if ROOT_VERSION_CODE >= ROOT_VERSION(6, 14, 0)
 //       /**
@@ -195,7 +195,7 @@ namespace dqm4hep {
        *
        *  @param  reports the list of quality test reports to receive
        */
-      core::StatusCode runQualityTests(core::QReportMap &reports);
+      core::StatusCode runQualityTests(core::QReportMap &reports) override;
 
       /** 
        *  @brief  Run a specific quality test
@@ -203,7 +203,7 @@ namespace dqm4hep {
        *  @param  name the quality test name to run
        *  @param  report the quality test report to receive
        */
-      core::StatusCode runQualityTest(const std::string &name, core::QReport &report);
+      core::StatusCode runQualityTest(const std::string &name, core::QReport &report) override;
 
     private:
       /// The run number


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix compilation error on gcc7+ (missing include for std::function)
- Fix new warnings from llvm7+ 

ENDRELEASENOTES
Fixes #55 